### PR TITLE
Let query constructor params omit precision

### DIFF
--- a/lib/primo/query.rb
+++ b/lib/primo/query.rb
@@ -74,7 +74,7 @@ class Primo::Pnxs::Query
   end
 
   private
-    REQUIRED_PARAMS = [ :field, :precision, :value ]
+    REQUIRED_PARAMS = [ :field, :value ]
     OPTIONAL_PARAMS = [ :operator ]
     PARAM_ORDER = [ :field, :precision, :value, :operator ]
     OPERATOR_VALUES = [ :AND, :OR, :NOT ]
@@ -108,6 +108,7 @@ class Primo::Pnxs::Query
     def push(params, operator = nil)
       params ||= {}
       operator = operator || params[:operator] || Primo.configuration.operator
+      params[:precision] ||= Primo.configuration.precision
       query = @queries.pop
 
       if query

--- a/spec/lib/primo/query_spec.rb
+++ b/spec/lib/primo/query_spec.rb
@@ -446,16 +446,6 @@ describe "#{Primo::Pnxs::Query} parameter validation"  do
   end
 
   #{{{2 :precision
-  context ":precision parameter is missing" do
-    let(:query) { Primo::Pnxs::Query.new(
-      field: :any,
-      value: "foo",
-    ) }
-    it "raises a query error" do
-      expect { query }.to raise_error(Primo::Pnxs::Query::QueryError)
-    end
-  end
-
   context ":precision parameter is not known" do
     let(:query) { Primo::Pnxs::Query.new(
       field: :any,


### PR DESCRIPTION
We set a default query precision in config, use it here.