### PR TITLE
Add to_h method.

### DIFF
--- a/lib/primo/pnxs.rb
+++ b/lib/primo/pnxs.rb
@@ -69,10 +69,8 @@ module Primo
 
       def params
         query = @params[:q]
-        p = @params.merge(auth).merge(q: query.to_s)
-        p.merge!(qInclude: query.include_facets) unless query.include_facets.nil?
-        p.merge!(qExclude: query.exclude_facets) unless query.exclude_facets.nil?
-        p
+        @params.merge(auth)
+          .merge(query.to_h)
       end
 
       def self.can_process?(params = {})

--- a/lib/primo/query.rb
+++ b/lib/primo/query.rb
@@ -46,6 +46,16 @@ class Primo::Pnxs::Query
       .join(";")
   end
 
+  def to_h
+    {
+      q: to_s,
+      qInclude: include_facets,
+      qExclude: exclude_facets,
+    }
+      .select { |k, v| !v.nil? }
+      .to_h
+  end
+
   def facet(params)
     facet = Primo::Pnxs::Facet.new(params)
     if facet.operation == :exclude
@@ -58,17 +68,13 @@ class Primo::Pnxs::Query
   end
 
   def include_facets
-    if @include_facets.empty?
-      nil
-    else
+    if !@include_facets.empty?
       @include_facets.map(&:to_s).join("|,|")
     end
   end
 
   def exclude_facets
-    if @exclude_facets.empty?
-      nil
-    else
+    if !@exclude_facets.empty?
       @exclude_facets.map(&:to_s).join("|,|")
     end
   end

--- a/spec/lib/primo/facet_spec.rb
+++ b/spec/lib/primo/facet_spec.rb
@@ -4,38 +4,38 @@ require "spec_helper"
 
 describe Primo::Pnxs::Facet  do
   context "pass minimal parameters" do
-    let(:facet) { described_class.new({
+    let(:facet) { described_class.new(
       field: "creator",
       value: "bar"
-    }) }
+    )}
     it "transforms to an expected string with defaults" do
       expect(facet).to be_a Primo::Pnxs::Facet
     end
   end
   context "Builds an exclude facet" do
-    let(:facet) { described_class.new({
+    let(:facet) { described_class.new(
       field: "creator",
       value: "a creator",
       operation: :exclude
-      }) }
-      it "successfully builds an exclude facet" do
-        expect(facet.operation).to eql(:exclude)
-      end
+    ) }
+    it "successfully builds an exclude facet" do
+      expect(facet.operation).to eql(:exclude)
     end
+  end
   context "params don't include :field" do
-    let(:facet) { described_class.new({
-        value: "bar"
-      }) }
-      it "raises an error" do
-        expect { facet }.to raise_error(Primo::Pnxs::Facet::FacetError)
-      end
+    let(:facet) { described_class.new(
+      value: "bar"
+    ) }
+    it "raises an error" do
+      expect { facet }.to raise_error(Primo::Pnxs::Facet::FacetError)
     end
-    context "params don't include :value" do
-      let(:facet) { described_class.new({
-        field: "creator"
-        }) }
-        it "transforms to an expected string with defaults" do
-          expect { facet }.to raise_error(Primo::Pnxs::Facet::FacetError)
-        end
-      end
+  end
+  context "params don't include :value" do
+    let(:facet) { described_class.new(
+      field: "creator"
+    ) }
+    it "transforms to an expected string with defaults" do
+      expect { facet }.to raise_error(Primo::Pnxs::Facet::FacetError)
     end
+  end
+end

--- a/spec/lib/primo/query_spec.rb
+++ b/spec/lib/primo/query_spec.rb
@@ -209,7 +209,7 @@ describe "#{Primo::Pnxs::Query}#or"  do
   end
 end
 
-describe "#{Primo::Pnxs::Query}#and"  do
+describe "#{Primo::Pnxs::Query}#not"  do
   context "add nil as the second query" do
     let(:query) {
       Primo.configure {}
@@ -512,6 +512,65 @@ describe "#{Primo::Pnxs::Query} parameter validation"  do
       expect(query.to_s).to include("A B C")
     end
   end
+
+  describe "#{Primo::Pnxs::Query}#to_h" do
+    let(:query) {
+      Primo.configure {}
+      Primo::Pnxs::Query.new(
+        precision: :exact,
+        field: :facet_local23,
+        value: "bar",
+      ) }
+    let(:facet1) { {
+      precision: :exact,
+      operation: :exclude,
+      field: "creator",
+      value: "bar"
+    } }
+    let(:facet2) { {
+      precision: :exact,
+      field: "format",
+      value: "foo"
+    } }
+
+    context "simple query with no facets" do
+      it "has one value" do
+        expect(query.to_h.size).to eq(1)
+      end
+
+      it "has a :q key" do
+        expect(query.to_h).to have_key(:q)
+      end
+    end
+
+    context "simple query with exclude facet" do
+      it "has two values" do
+        query.facet(facet1)
+        expect(query.to_h.size).to eq(2)
+      end
+
+      it "has a :qInclude key" do
+        query.facet(facet1)
+        expect(query.to_h).to have_key(:qExclude)
+      end
+    end
+
+    context "simple query with include facet" do
+      it "has a :qInclude key" do
+        query.facet(facet2)
+        expect(query.to_h).to have_key(:qInclude)
+      end
+    end
+
+    context "simple query with include and exclude facets" do
+      it "has 3 values" do
+        query.facet(facet1).facet(facet2)
+        expect(query.to_h.size).to eq(3)
+      end
+    end
+
+  end
+
 
   describe "#{Primo::Pnxs::Query}#facet"  do
     let(:query) {


### PR DESCRIPTION
This commit adds a `to_h` method to Primo::Pnxs::Query that is then used
to more canonically merge it into a set of other url parameters.

This commit also removes some redundancy in the
`Primo::Pnxs::Query.include_facets,exclude_facets` methods that were
explicitly returning `nil` despite not needing to.

Lastly this commit makes some formatting changes to make Rubocop happy.