### PR TITLE
Add required changes for blacklight intergration

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ query.facet({
     field: "format",
     value: "Book"
     })
+```
 
       
 #### Generating advanced queries with advanced operators

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "primo"

--- a/lib/primo.rb
+++ b/lib/primo.rb
@@ -11,13 +11,13 @@ module Primo
   def self.find(options = {})
     options ||= {}
 
-    if options.instance_of? String
+    if options.is_a? String
       params = find_defaults(value: options)
       query = Primo::Pnxs::Query.new params
       return find(q: query)
     end
 
-    if  options.fetch(:q, {}).instance_of? Hash
+    if  options.fetch(:q, {}).is_a? Hash
       query = Primo::Pnxs::Query.new(find_defaults options[:q])
       return find(options.merge(q: query))
     end
@@ -28,7 +28,7 @@ module Primo
   def self.find_by_id(params = {})
     params ||= {}
 
-    if params.instance_of? String
+    if params.is_a? String
       return find_by_id(id: params)
     end
 

--- a/lib/primo.rb
+++ b/lib/primo.rb
@@ -17,6 +17,10 @@ module Primo
       return find(q: query)
     end
 
+    if options.fetch(:id, nil)
+      return find_by_id(options)
+    end
+
     if  options.fetch(:q, {}).is_a? Hash
       query = Primo::Pnxs::Query.new(find_defaults options[:q])
       return find(options.merge(q: query))

--- a/lib/primo/facet.rb
+++ b/lib/primo/facet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Primo::Pnxs::Facet
   class FacetError < ArgumentError
   end
@@ -21,36 +23,35 @@ class Primo::Pnxs::Facet
 
   private
 
-  DEFAUlT_PRECISION = :exact
-  DEFAULT_OPERATION = :include
+    DEFAUlT_PRECISION = :exact
+    DEFAULT_OPERATION = :include
 
-  # nil allowed because defaults will be filled in
-  ALLOWED_PRECISION = [nil, :exact]
-  ALLOWED_OPERATION = [nil, :include, :exclude]
+    # nil allowed because defaults will be filled in
+    ALLOWED_PRECISION = [nil, :exact]
+    ALLOWED_OPERATION = [nil, :include, :exclude]
 
-  REQUIRED_PARAMS = [:field, :value]
+    REQUIRED_PARAMS = [:field, :value]
 
 
-  def validators
-    [{ query: :acceptable_operation?,
-      message: lambda { |p| "Operation must be :include, :exclude, or not passed (nil) " } },
-    { query: :acceptable_precision?,
-      message: lambda { |p| "Precision must be :exact or not passed (nil)" } },
-    { query: :has_required_params?,
-      message: lambda { |p| "Both :field and :value must be defined"} }
-    ]
-  end
+    def validators
+      [{ query: :acceptable_operation?,
+        message: lambda { |p| "Operation must be :include, :exclude, or not passed (nil) " } },
+      { query: :acceptable_precision?,
+        message: lambda { |p| "Precision must be :exact or not passed (nil)" } },
+      { query: :has_required_params?,
+        message: lambda { |p| "Both :field and :value must be defined" } }
+      ]
+    end
 
-  def acceptable_precision?(params)
-    ALLOWED_PRECISION.include?(params.fetch(:precision, nil))
-  end
+    def acceptable_precision?(params)
+      ALLOWED_PRECISION.include?(params.fetch(:precision, nil))
+    end
 
-  def acceptable_operation?(params)
-    ALLOWED_OPERATION.include?(params.fetch(:operation, nil))
-  end
+    def acceptable_operation?(params)
+      ALLOWED_OPERATION.include?(params.fetch(:operation, nil))
+    end
 
-  def has_required_params?(params)
-    (REQUIRED_PARAMS - params.keys).empty?
-  end
-
+    def has_required_params?(params)
+      (REQUIRED_PARAMS - params.keys).empty?
+    end
 end

--- a/lib/primo/parameter_validatable.rb
+++ b/lib/primo/parameter_validatable.rb
@@ -1,48 +1,49 @@
+# frozen_string_literal: true
+
 module Primo
   module ParameterValidatable
-
-# A mixin class designed to allow Validations of params
-# To use, include it in your class and then define an array of validators
-# that are hashes with a :query and :message keys.
-#  :query is a method you will pass the params to to run a single validations
-#  :message is a lmbda that retunrs a string telling the user what went wrong
-#    - the params will be passed to the message so you can
-#      reference the params in your error message
-#
-# EXAMPLE Usage #####################
-# include Primo::ParameterValidatable
-#
-# def validators
-#   [{ query: is_my_param_valid?,
-#      message: lambda { |params| "Param :q needs to be an integer, but you passed a #{params[:q].class}"  }
-#   }]
-# def is_my_param_valid?(params)
-#   params[:count].is_a? Integer 
-#
-#######################################33
-
+    # A mixin class designed to allow Validations of params
+    # To use, include it in your class and then define an array of validators
+    # that are hashes with a :query and :message keys.
+    #  :query is a method you will pass the params to to run a single validations
+    #  :message is a lmbda that retunrs a string telling the user what went wrong
+    #    - the params will be passed to the message so you can
+    #      reference the params in your error message
+    #
+    # EXAMPLE Usage #####################
+    # include Primo::ParameterValidatable
+    #
+    # def validators
+    #   [{ query: is_my_param_valid?,
+    #      message: lambda { |params| "Param :q needs to be an integer, but you passed a #{params[:q].class}"  }
+    #   }]
+    # def is_my_param_valid?(params)
+    #   params[:count].is_a? Integer
+    #
+    #######################################33
 
 
-   def validate(params)
-     validators.each do |validate|
-       message = validate[:message][params]
-       if !send(validate[:query], params)
-         raise error.new(message)
-       end
-     end
-   end
 
-   # Use a local error class if the Class has a local error class
-   # following the convention Primo::ClassName::ClassNameError
-   # Otherwise use Primo::Pnxs::PnxsError
-   def error
-     error_class = Primo::Pnxs::PnxsError
-     class_name = self.class.to_s.split("::").last
-     class_error_name = class_name + "Error"
-     if self.class.const_defined?(class_error_name)
-       error_class = self.class.const_get(class_error_name)
-     end
-     error_class
-   end
+    def validate(params)
+      validators.each do |validate|
+        message = validate[:message][params]
+        if !send(validate[:query], params)
+          raise error.new(message)
+        end
+      end
+    end
+
+    # Use a local error class if the Class has a local error class
+    # following the convention Primo::ClassName::ClassNameError
+    # Otherwise use Primo::Pnxs::PnxsError
+    def error
+      error_class = Primo::Pnxs::PnxsError
+      class_name = self.class.to_s.split("::").last
+      class_error_name = class_name + "Error"
+      if self.class.const_defined?(class_error_name)
+        error_class = self.class.const_get(class_error_name)
+      end
+      error_class
+    end
  end
 end

--- a/lib/primo/query.rb
+++ b/lib/primo/query.rb
@@ -141,7 +141,7 @@ class Primo::Pnxs::Query
     end
 
     def field_is_known?(params)
-      field = params[:field].to_sym
+      field = params.fetch(:field, :missing_field).to_sym
       REGULAR_FIELDS.include?(field) || FACET_FIELDS.include?(field)
     end
 

--- a/spec/lib/primo/query_spec.rb
+++ b/spec/lib/primo/query_spec.rb
@@ -8,7 +8,7 @@ describe "#{Primo::Pnxs::Query} simple query"  do
       Primo.configure {}
       Primo::Pnxs::Query.new(
         precision: :exact,
-        field: :facet_local23,
+        "field" => :facet_local23,
         value: "bar",
       ) }
     it "transforms to an expected string" do
@@ -20,10 +20,10 @@ describe "#{Primo::Pnxs::Query} simple query"  do
     let(:query) {
       Primo.configure {}
       Primo::Pnxs::Query.new(
-        precision: :exact,
-        field: :facet_local23,
-        value: "bar",
-        operator: :OR,
+        "precision" => :exact,
+        "field" =>  :facet_local23,
+        "value" => "bar",
+        "operator" => :OR,
       ) }
     it "transforms to an expected string" do
       expect(query.to_s).to eq("facet_local23,exact,bar,OR")

--- a/spec/primo_spec.rb
+++ b/spec/primo_spec.rb
@@ -90,6 +90,14 @@ RSpec.describe "Primo.find" do
       expect { Primo.find query }.not_to raise_error
     end
   end
+
+  context "when we pass object with id" do
+    let(:query) {  { id: "foo" } }
+
+    it "does not raise a query error" do
+      expect { Primo.find query }.not_to raise_error
+    end
+  end
 end
 
 RSpec.describe "Primo.find_by_id" do

--- a/spec/primo_spec.rb
+++ b/spec/primo_spec.rb
@@ -57,6 +57,20 @@ RSpec.describe "Primo.find" do
     end
   end
 
+  context "when we pass options with valid q hash" do
+    let(:query) {
+      Primo::Pnxs::Query.new(
+        "precision" =>  "contains",
+        "field" => "title",
+        "value" =>  "otter",
+        "opterator" => "OR",
+      )
+    }
+    it "does not raise a query error" do
+      expect { Primo.find q: query }.not_to raise_error
+    end
+  end
+
   context "when we pass options with valid q Query instance" do
     let(:query) {
       { precision: :contains,


### PR DESCRIPTION
Some changes are needed to help integrate this more easily with a blacklight instance:

* When initializing a query we need to allow for keys and values to be
strings because blacklight automatically turns symbols in params into
strings.

* Update `Primo.find` so that it knows how to handle searching for single documents (i.e. passes id to find_by_id method)