### PR TITLE
Allow date range fields.

### DIFF
--- a/lib/primo/query.rb
+++ b/lib/primo/query.rb
@@ -89,7 +89,7 @@ class Primo::Pnxs::Query
     REGULAR_FIELDS = %i(
       any desc title creator sub subject rtype isbn issn rectype dlink
       ftext general toc fmt lang cdate sid rid addsrcrid addtitle
-      pnxtype alttitle abstract fiction
+      pnxtype alttitle abstract fiction s_dr e_dr
     )
     FACET_FIELDS = %i(
       facet_creator facet_lang facet_rtype facet_pfilter facet_topic


### PR DESCRIPTION
Although not currently documented, Primo PNXS does allow queries on date
ranges:  BL-350

This is also allowed via the facet, but we already capture the
appropriate faceted field that can be searched against a range.