### PR TITLE
Use default :context and :field

### DIFF
--- a/lib/primo.rb
+++ b/lib/primo.rb
@@ -12,13 +12,12 @@ module Primo
     options ||= {}
 
     if options.is_a? String
-      params = find_defaults(value: options)
-      query = Primo::Pnxs::Query.new params
+      query = Primo::Pnxs::Query.new(value: options)
       return find(q: query)
     end
 
     if  options.fetch(:q, nil).is_a? Hash
-      query = Primo::Pnxs::Query.new(find_defaults options[:q])
+      query = Primo::Pnxs::Query.new(options[:q])
       return find(options.merge(q: query))
     end
 
@@ -32,22 +31,6 @@ module Primo
       return find_by_id(id: params)
     end
 
-    Primo::Pnxs::get(id_defaults(params))
+    Primo::Pnxs::get(params)
   end
-
-  private
-
-    # TODO: Move these defaults to query methods.
-    def self.find_defaults(params)
-      params ||= {}
-      field = params[:field] || Primo.configuration.field
-      precision = params[:precision] || Primo.configuration.precision
-      params.merge(field: field, precision: precision)
-    end
-
-    def self.id_defaults(params)
-      params ||= {}
-      context = params[:context] || Primo.configuration.context
-      params.merge(context: context)
-    end
 end

--- a/lib/primo/pnxs.rb
+++ b/lib/primo/pnxs.rb
@@ -119,7 +119,7 @@ module Primo
     # URL and Parameters.
     class RecordMethod < PnxsMethod
       def url
-        context = @params[:context]
+        context = @params[:context] || Primo.configuration.context
         id = @params[:id]
         Primo.configuration.region + RESOURCE + "/#{context}/#{id}"
       end

--- a/lib/primo/query.rb
+++ b/lib/primo/query.rb
@@ -116,6 +116,7 @@ class Primo::Pnxs::Query
       params = params.map { |k, v| [k.to_sym, v] }.to_h
 
       operator = operator || params[:operator] || Primo.configuration.operator
+      params[:field] ||= Primo.configuration.field
       params[:precision] ||= Primo.configuration.precision
 
       query = @queries.pop
@@ -182,4 +183,5 @@ class Primo::Pnxs::Query
     def operator(value)
       value || Primo.configuration.operator
     end
+
 end

--- a/spec/lib/primo/query_spec.rb
+++ b/spec/lib/primo/query_spec.rb
@@ -393,8 +393,8 @@ describe "#{Primo::Pnxs::Query} parameter validation"  do
       precision: "contains",
       value: "foo"
     ) }
-    it "raises a query error" do
-      expect { query }.to raise_error(Primo::Pnxs::Query::QueryError)
+    it "Uses the default field if not provided" do
+      expect { query }.to_not raise_error(Primo::Pnxs::Query::QueryError)
     end
   end
 


### PR DESCRIPTION
A previous refactor incorrectly handled some cases when either a default
:field and a default :context should be used.  This commit fixes that
issue.