### PR TITLE
Allow query to build from array of values.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.4
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.
   DisabledByDefault: true

--- a/lib/primo.rb
+++ b/lib/primo.rb
@@ -16,8 +16,14 @@ module Primo
       return find(q: query)
     end
 
-    if  options.fetch(:q, nil).is_a? Hash
-      query = Primo::Pnxs::Query.new(options[:q])
+    if  options[:q]&.is_a? Hash
+      if options[:q][:value]&.is_a? Array
+        queries = options[:q][:value]
+        query = Primo::Pnxs::Query.build(queries)
+      else
+        query = Primo::Pnxs::Query.new(options[:q])
+      end
+
       return find(options.merge(q: query))
     end
 
@@ -31,6 +37,6 @@ module Primo
       return find_by_id(id: params)
     end
 
-    Primo::Pnxs::get(params)
+    find(params)
   end
 end

--- a/spec/primo_spec.rb
+++ b/spec/primo_spec.rb
@@ -98,6 +98,15 @@ RSpec.describe "Primo.find" do
       expect { Primo.find query }.not_to raise_error
     end
   end
+
+  context "when value is an array" do
+    let(:query) { { q: { value: [] } } }
+
+    it "builds the query using the Primo::Pnxs::Query.build method" do
+      expect(Primo::Pnxs::Query).to receive(:build).with([])
+      begin Primo.find(query) rescue nil end
+    end
+  end
 end
 
 RSpec.describe "Primo.find_by_id" do


### PR DESCRIPTION
REF BL-414

We already have a way to build up a query using an array of query
definitions. Now we can pass in `{ q: { value: [..] } }` where value is
an array of query definitions into `Primo.find` and have that be
processed correctly.