### PR TITLE
Fix query builds in wrong order.

### DIFF
--- a/lib/primo/query.rb
+++ b/lib/primo/query.rb
@@ -33,7 +33,7 @@ class Primo::Pnxs::Query
 
   def self.build(queries)
     queries ||= []
-    first_query = queries.pop
+    first_query = queries.shift
     query = new(first_query)
     queries.each { |q|
       query.send(:push, q)
@@ -111,18 +111,19 @@ class Primo::Pnxs::Query
           message: lambda { |p| "Attempt to use non exact precision with facet field: #{p[:precision]}" } },
       ]
 
-    def push(params, operator = nil)
+    def push(params, op_overrider = nil)
       params ||= {}
       params = params.map { |k, v| [k.to_sym, v] }.to_h
 
-      operator = operator || params[:operator] || Primo.configuration.operator
+      params[:operator] ||= Primo.configuration.operator
       params[:field] ||= Primo.configuration.field
       params[:precision] ||= Primo.configuration.precision
 
       query = @queries.pop
 
       if query
-        @queries.push(query.merge(operator: operator))
+        query[:operator] = op_overrider if op_overrider
+        @queries.push(query)
       end
 
       validate(params) && @queries.push(params)

--- a/spec/lib/primo/query_spec.rb
+++ b/spec/lib/primo/query_spec.rb
@@ -342,15 +342,21 @@ describe "#{Primo::Pnxs::Query}::build" do
     let(:query) { {
       precision: :contains,
       field: :title,
+      value: "foo",
+      operator: :NOT,
+    } }
+    let(:query_2) { {
+      precision: :contains,
+      field: :title,
       value: "bar",
-      operator: :OR,
+      operator: :AND,
     } }
     it "it returns a Query" do
-      expect(Primo::Pnxs::Query::build([query, query, query])).to be_an_instance_of(Primo::Pnxs::Query)
+      expect(Primo::Pnxs::Query::build([query, query, query_2])).to be_an_instance_of(Primo::Pnxs::Query)
     end
 
     it "transforms to an expected string" do
-      expect(Primo::Pnxs::Query::build([query, query]).to_s).to eq("title,contains,bar,OR;title,contains,bar,OR")
+      expect(Primo::Pnxs::Query::build([query, query_2]).to_s).to eq("title,contains,foo,NOT;title,contains,bar,AND")
     end
   end
 


### PR DESCRIPTION
This commit fixes two bugs found in the query buider:
* The order of the built query is in the opposite direction than it's
individual components.
* Under some conditions a query operator can be unintentionally
overridden.