### PR TITLE
Remove semicolon from search value.

### DIFF
--- a/lib/primo/query.rb
+++ b/lib/primo/query.rb
@@ -178,11 +178,10 @@ class Primo::Pnxs::Query
     end
 
     def value(value)
-      value.to_s.tr(",", " ")
+      value.to_s.gsub(/(,|;)/, " ")
     end
 
     def operator(value)
       value || Primo.configuration.operator
     end
-
 end

--- a/spec/lib/primo/query_spec.rb
+++ b/spec/lib/primo/query_spec.rb
@@ -509,6 +509,18 @@ describe "#{Primo::Pnxs::Query} parameter validation"  do
     end
   end
 
+  context ":value including semicolons" do
+    let(:query) { Primo::Pnxs::Query.new(
+      field: :any,
+      precision: :contains,
+      value: "A;B;C",
+    ) }
+
+    it "replaces semicolons with spaces" do
+      expect(query.to_s).to include("A B C")
+    end
+  end
+
   describe "#{Primo::Pnxs::Query}#to_h" do
     let(:query) {
       Primo.configure {}


### PR DESCRIPTION
REF BL-586
REF https://app.honeybadger.io/projects/56250/faults/39087792

Remove semicolons from search value cause they mess up the URL for the
PNX api.