### PR TITLE
Fix # in id breaks primo path.

### DIFF
--- a/lib/primo/pnxs.rb
+++ b/lib/primo/pnxs.rb
@@ -120,7 +120,9 @@ module Primo
     class RecordMethod < PnxsMethod
       def url
         context = @params[:context] || Primo.configuration.context
-        id = URI.encode(URI.decode(@params[:id]))
+        id = URI.decode(@params[:id])
+        id = id.gsub(/#/, "")
+        id = URI.encode(id)
         Primo.configuration.region + RESOURCE + "/#{context}/#{id}"
       end
 


### PR DESCRIPTION
REF BL-593

If there is a # in the id then it breaks the Primo document api even if
the id is URL encoded.