### PR TITLE
Use CGI.escape vs URI.encode.

### DIFF
--- a/lib/primo/pnxs.rb
+++ b/lib/primo/pnxs.rb
@@ -120,7 +120,7 @@ module Primo
     class RecordMethod < PnxsMethod
       def url
         context = @params[:context] || Primo.configuration.context
-        id = URI.encode(URI.decode(@params[:id]))
+        id = CGI.escape(URI.unescape @params[:id])
         Primo.configuration.region + RESOURCE + "/#{context}/#{id}"
       end
 


### PR DESCRIPTION
REF BL-593

URI.encode was missing some characters that broke path to API.
CGI.escape does not have the problem.