### PR TITLE
Switch primo search resource.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Primo.configure do |config|
   
   # By default scope will be nil
   config.scope = "pci_scope"
+
+  # By default the pcAvailability is set to false
+  config.pcavailability = false
 end
 ```
 Now you can access those configuration attributes with `Primo.configuration.apikey`

--- a/lib/primo/config.rb
+++ b/lib/primo/config.rb
@@ -12,7 +12,7 @@ module Primo
 
   class Configuration
     attr_accessor :apikey, :region, :operator, :field, :precision
-    attr_accessor :context, :environment, :inst, :vid, :scope
+    attr_accessor :context, :environment, :inst, :vid, :scope, :pcavailability
 
     def initialize
       @apikey = "TEST_API_KEY"
@@ -23,6 +23,7 @@ module Primo
       @precision = :contains
       @context = :L
       @environment = :hosted
+      @pcavailability = false
     end
   end
 end

--- a/lib/primo/pnxs.rb
+++ b/lib/primo/pnxs.rb
@@ -76,7 +76,7 @@ module Primo
     # Encapsolates the GET /v1/pnxs Primo REST API Method URL and Parameters.
     class SearchMethod < PnxsMethod
       def url
-        Primo.configuration.region + RESOURCE
+        Primo.configuration.region + "/primo/v1/search"
       end
 
       def params
@@ -95,7 +95,7 @@ module Primo
 
         PARAMETER_KEYS = %i(
           inst q qInclude qExclude lang offset limit sort
-          view addfields vid scope
+          view addfields vid scope apikey
         )
 
         def validators
@@ -137,7 +137,7 @@ module Primo
       private
 
         URL_KEYS = %i(id context)
-        PARAMETER_KEYS = %i( inst lang )
+        PARAMETER_KEYS = %i( inst lang apikey)
 
         def validators
           [

--- a/lib/primo/pnxs.rb
+++ b/lib/primo/pnxs.rb
@@ -95,7 +95,7 @@ module Primo
 
         PARAMETER_KEYS = %i(
           inst q qInclude qExclude lang offset limit sort
-          view addfields vid scope apikey
+          view addfields vid scope
         )
 
         def validators
@@ -137,7 +137,7 @@ module Primo
       private
 
         URL_KEYS = %i(id context)
-        PARAMETER_KEYS = %i( inst lang apikey)
+        PARAMETER_KEYS = %i( inst lang )
 
         def validators
           [

--- a/lib/primo/pnxs.rb
+++ b/lib/primo/pnxs.rb
@@ -84,6 +84,7 @@ module Primo
         @params.merge(auth)
           .merge(vid_scope)
           .merge(query.to_h)
+          .merge(pcAvailability: Primo.configuration.pcavailability)
       end
 
       def self.can_process?(params = {})

--- a/spec/lib/primo/config_spec.rb
+++ b/spec/lib/primo/config_spec.rb
@@ -21,6 +21,7 @@ describe "Configuring Primo" do
       expect(Primo.configuration.environment).to eql :hosted
       expect(Primo.configuration.vid).to eql nil
       expect(Primo.configuration.scope).to eql nil
+      expect(Primo.configuration.pcavailability).to eql false
     end
 
     after(:all) do


### PR DESCRIPTION
REF BL-605

The primo/v1/pnxs resource is deprecated this change updates the
resource to a new path.

This change also makes apikey configurable via parameters, which allows
us to use two separate resource path using the same code base.