### PR TITLE
apply information about a bad primo response to the gem's SearchError…

### DIFF
--- a/lib/primo/parameter_validatable.rb
+++ b/lib/primo/parameter_validatable.rb
@@ -23,12 +23,15 @@ module Primo
     #######################################33
 
 
-
     def validate(params)
       validators.each do |validate|
         message = validate[:message][params]
         if !send(validate[:query], params)
-          raise error.new(message)
+          if params.respond_to?(:request) && params.request.respond_to?(:uri)
+            message += "\nEndpoint: #{params.request.uri.to_s}"
+          end
+
+          raise error_class.new(message)
         end
       end
     end
@@ -36,7 +39,7 @@ module Primo
     # Use a local error class if the Class has a local error class
     # following the convention Primo::ClassName::ClassNameError
     # Otherwise use Primo::Search::SearchError
-    def error
+    def error_class
       error_class = Primo::Search::SearchError
       class_name = self.class.to_s.split("::").last
       class_error_name = class_name + "Error"

--- a/lib/primo/search.rb
+++ b/lib/primo/search.rb
@@ -7,6 +7,7 @@ module Primo
   # Encapsulates the Primo Search REST API
   class Search
     class SearchError < StandardError
+
       def initialize(message, loggable = {})
         if Primo.configuration.enable_loggable
           message = loggable.merge(error: message).to_json
@@ -217,7 +218,7 @@ module Primo
     def validators
       [
         { query: :is_200?,
-          message: lambda { |r| "Attempting to work with an invalid response: #{r.code}" } },
+          message: lambda { |r| "Attempting to work with an invalid response: #{r.code}" } }
       ]
     end
 


### PR DESCRIPTION
… object

Allows the blacklight app to provide meaningful info to honeybadger when primo responds with a server error. Example:

https://app.honeybadger.io/projects/72785/faults/66381370