### PR TITLE
BL-1714: Allow override of pcavailability param.

### DIFF
--- a/lib/primo/search.rb
+++ b/lib/primo/search.rb
@@ -48,6 +48,7 @@ module Primo
 
     # Overrides HTTParty::get in order to add some custom validations.
     def self.get(params = {})
+      params = params.to_h.transform_keys(&:to_sym)
       method = get_method params
       (url, query) = url(params)
       new super(url, query: query, timeout: Primo.configuration.timeout(params)), method
@@ -57,6 +58,7 @@ module Primo
       method = get_method params
       [method.url, method.params]
     end
+
 
   private
     # Base class for classes encapsulating Primo REST API methods.
@@ -127,6 +129,7 @@ module Primo
         PARAMETER_KEYS = %i(
           inst q qInclude qExclude lang offset limit sort
           view addfields vid scope searchCDI
+          apikey inst pcAvailability pcavailability vid scope
         )
 
         def validators
@@ -185,7 +188,7 @@ module Primo
       private
 
         URL_KEYS = %i(id context)
-        PARAMETER_KEYS = %i(inst lang searchCDI, apikey, inst, pcAvailability, pcavailability, vid, scope)
+        PARAMETER_KEYS = %i(inst lang searchCDI apikey inst pcAvailability pcavailability vid scope)
 
         def validators
           [

--- a/lib/primo/search.rb
+++ b/lib/primo/search.rb
@@ -109,10 +109,12 @@ module Primo
 
       def params
         query = @params[:q] || @params["q"]
-        @params.merge(auth)
+        # Add defaults and allow override of defaults via @params.
+        {}.merge(auth)
           .merge(vid_scope)
           .merge(query.to_h)
           .merge(pcAvailability: Primo.configuration.pcavailability)
+          .merge(@params.slice(*@params.keys - [:q, "q"]))
       end
 
       def self.can_process?(params = {})
@@ -163,9 +165,11 @@ module Primo
       end
 
       def params
-        @params.merge(vid_scope)
-          .select { |k, v| !URL_KEYS.include? k }
+        # Add defaults and allow override by passed in @params.
+        {}.merge(vid_scope)
           .merge auth
+          .merge(@params)
+          .select { |k, v| !URL_KEYS.include? k }
       end
 
       def self.can_process?(params = {})
@@ -181,7 +185,7 @@ module Primo
       private
 
         URL_KEYS = %i(id context)
-        PARAMETER_KEYS = %i(inst lang searchCDI)
+        PARAMETER_KEYS = %i(inst lang searchCDI, apikey, inst, pcAvailability, pcavailability, vid, scope)
 
         def validators
           [

--- a/spec/lib/primo/search_spec.rb
+++ b/spec/lib/primo/search_spec.rb
@@ -59,10 +59,10 @@ RSpec.describe "#{Primo::Search}#get" do
       )
       { q: q, pcavailability: "foo" }
 
-    it "uses the pcAvailability override provided via user params" do
-      method = Primo::Search.send(:get_method, params)
-      expect(method.params[:pcavailability]).to eq("foo")
-    end
+      it "uses the pcAvailability override provided via user params" do
+        method = Primo::Search.send(:get_method, params)
+        expect(method.params[:pcavailability]).to eq("foo")
+      end
     }
   end
 

--- a/spec/lib/primo/search_spec.rb
+++ b/spec/lib/primo/search_spec.rb
@@ -66,6 +66,23 @@ RSpec.describe "#{Primo::Search}#get" do
     }
   end
 
+  context "passing in an override for pcAvailability but where key is a string" do
+    let(:params) {
+      q = Primo::Search::Query.new(
+        precision: :exact,
+        field: :facet_local23,
+        value: "bar",
+        operator: :OR,
+      )
+      { q: q, "pcavailability" => "bar" }
+
+      it "uses the pcAvailability override provided via user params" do
+        method = Primo::Search.send(:get_method, params)
+        expect(method.params[:pcavailability]).to eq("bar")
+      end
+    }
+  end
+
   context "passing a valid query" do
     let(:options) {
       q = Primo::Search::Query.new(

--- a/spec/lib/primo/search_spec.rb
+++ b/spec/lib/primo/search_spec.rb
@@ -49,6 +49,23 @@ RSpec.describe "#{Primo::Search}#get" do
     end
   end
 
+  context "passing in an override for pcAvailability" do
+    let(:params) {
+      q = Primo::Search::Query.new(
+        precision: :exact,
+        field: :facet_local23,
+        value: "bar",
+        operator: :OR,
+      )
+      { q: q, pcavailability: "foo" }
+
+    it "uses the pcAvailability override provided via user params" do
+      method = Primo::Search.send(:get_method, params)
+      expect(method.params[:pcavailability]).to eq("foo")
+    end
+    }
+  end
+
   context "passing a valid query" do
     let(:options) {
       q = Primo::Search::Query.new(
@@ -175,7 +192,7 @@ RSpec.describe Primo::Search do
       expect { Primo::Search::get q: q }.to raise_error { |error|
         lines = error.message.split("\n")
         expect(lines[0]).to eq "Attempting to work with an invalid response: 500"
-        expect(lines[1]).to eq "Endpoint: https://www.foobar.com/primo/v1/search?q=title%2Ccontains%2Cotter%2COR&apikey=TEST_API_KEY&vid=&scope=&pcAvailability=false"
+        expect(lines[1]).to eq "Endpoint: https://www.foobar.com/primo/v1/search?apikey=TEST_API_KEY&vid=&scope=&q=title%2Ccontains%2Cotter%2COR&pcAvailability=false"
       }
     end
   end


### PR DESCRIPTION
If user submits pcavailability value via a param, use that instead of the
default set in the Primo.configuration.