### PR TITLE
BL-864: Allow logging for Primo::Search class via config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,24 @@ Primo.configure do |config|
 
   # By default we validate parameters.
   config.validate_parameters = false
+
+  # We do not enable primo request logs by default
+  config.enable_log_requests = false
+
+  # By default we use the built in Ruby logger, but you can set it to another logger
+  config.logger = Logger.new("log/primo_requests.log")
+
+  # Log level is set to :info by default
+  config.log_level = :info
+
+  # Log format is set to :logstash by deafult
+  config.log_format = :logstash
+
+  # debugging output is disabled by default
+  config.enable_debug_output = false
+
+  # The debug_output_stream is set to $stderr by default
+  config.debug_output_stream = $stderr
 end
 ```
 Now you can access those configuration attributes with `Primo.configuration.apikey`
@@ -202,9 +220,27 @@ Primo::Search::Query::build([q1, q2])
 This API wrapper validates the `query` object according the specifications documented in [the Ex Libris Api docs](https://developers.exlibrisgroup.com/primo/apis/webservices/xservices/search/briefsearch) for the `query` field.
 
 ### Logging
+
+#### Using :enable_loggable
 This gem exposes a loggable interface to responses.  Thus a response will respond to `loggable` and return a hash with state values that may be of use to log.
 
 As a bonus, when we enable this feature using the `enable_loggable` configuration, error messages will contain the loggable values and be formatted as JSON.
+
+#### Using logging configuration.
+You can configure logging via the following configurations:
+* `enable_log_requests`: (`true/false`)
+* `log_level`
+* `log_format`
+* `logger`
+
+The logger can be any logger including the Rails.logger.  This logging feature is provided through [HTTParty](https://www.rubydoc.info/github/jnunemaker/httparty/HTTParty/ClassMethods#logger-instance_method).
+
+### Debugging requests
+You can configure debugging requests by setting the `enable_debug_output` configuration which is false by default. This feature is also provided through [HTTParty](https://www.rubydoc.info/github/jnunemaker/httparty/HTTParty/ClassMethods#debug_output-instance_method).
+
+You can configure the `debug_output_stream` which is set to `$stderr` by default.
+
+
 
 ## Development
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/primo/config.rb
+++ b/lib/primo/config.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "logger"
+
 module Primo
   class << self
     attr_accessor :configuration
@@ -8,12 +10,35 @@ module Primo
   def self.configure()
     self.configuration ||= Configuration.new
     yield(configuration) if block_given?
+    on_configure
+  end
+
+  def self.on_configure
+    _configure_logging
+    _configure_debugging
+  end
+
+
+  def self._configure_logging
+    if configuration.enable_log_requests
+      primo_logger = configuration.logger
+      log_level = Primo.configuration.log_level
+      log_format = Primo.configuration.log_format
+      Primo::Search.logger primo_logger, log_level, log_format
+    end
+  end
+
+  def self._configure_debugging
+    if configuration.enable_debug_output
+      Primo::Search.debug_output configuration.debug_output_stream
+    end
   end
 
   class Configuration
     attr_accessor :apikey, :region, :operator, :field, :precision
     attr_accessor :context, :environment, :inst, :vid, :scope, :pcavailability, :enable_loggable
-    attr_accessor :timeout, :validate_parameters
+    attr_accessor :timeout, :validate_parameters, :enable_log_requests, :enable_debug_output
+    attr_accessor :logger, :log_level, :log_format, :debug_output_stream
 
     def initialize
       @apikey = "TEST_API_KEY"
@@ -28,6 +53,13 @@ module Primo
       @enable_loggable = false
       @timeout = 5
       @validate_parameters = true
+      @enable_log_requests = false
+      # debug_output should only be enabled in development mode.
+      @enable_debug_output = false
+      @logger = Logger.new("log/primo_requests.log")
+      @log_level = :info
+      @log_format = :logstash
+      @debug_output_stream = $stderr
     end
 
     def timeout(params = {})


### PR DESCRIPTION
* Also allows enabling debugging of Primo::Search requests via configuration.